### PR TITLE
Fix snarkVM issue 2956

### DIFF
--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -69,15 +69,36 @@ use snarkvm_utilities::{
     BitIteratorBE,
     biginteger::{BigInteger, BigInteger256, BigInteger384},
     rand::{TestRng, Uniform},
+    serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate},
 };
 
 use rand::Rng;
 use std::{
     cmp::Ordering,
+    fmt::Debug,
     ops::{AddAssign, Mul, MulAssign, SubAssign},
 };
 
 pub(crate) const ITERATIONS: usize = 10;
+
+fn assert_canonical_roundtrip<T>(value: &T)
+where
+    T: Clone + PartialEq + Debug + CanonicalSerialize + CanonicalDeserialize,
+{
+    let combinations = [
+        (Compress::No, Validate::No),
+        (Compress::Yes, Validate::No),
+        (Compress::No, Validate::Yes),
+        (Compress::Yes, Validate::Yes),
+    ];
+    for (compress, validate) in combinations {
+        let mut serialized = Vec::new();
+        value.serialize_with_mode(&mut serialized, compress).unwrap();
+        let decoded = T::deserialize_with_mode(&serialized[..], compress, validate).unwrap();
+        assert_eq!(value.clone(), decoded);
+        assert_eq!(value.serialized_size(compress), serialized.len());
+    }
+}
 
 #[test]
 fn test_bls12_377_fr() {
@@ -145,6 +166,31 @@ fn test_bls12_377_fq12() {
     }
     frobenius_test::<Fq12, _>(Fq::characteristic(), 13, &mut rng);
     field_serialization_test::<Fq12>(&mut rng);
+}
+
+#[test]
+fn test_bls12_377_fr_canonical_serialization() {
+    let mut rng = TestRng::default();
+    assert_canonical_roundtrip(&Fr::zero());
+    assert_canonical_roundtrip(&Fr::one());
+    for _ in 0..ITERATIONS {
+        let element: Fr = rng.gen();
+        assert_canonical_roundtrip(&element);
+    }
+}
+
+#[test]
+fn test_bls12_377_g1_affine_canonical_serialization() {
+    assert_canonical_roundtrip(&G1Affine::zero());
+    assert_canonical_roundtrip(&G1Affine::prime_subgroup_generator());
+
+    let generator = G1Projective::prime_subgroup_generator();
+    let mut current = G1Projective::zero();
+    for _ in 0..ITERATIONS {
+        current += &generator;
+        let affine = G1Affine::from(current);
+        assert_canonical_roundtrip(&affine);
+    }
 }
 
 #[test]

--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -201,7 +201,8 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
 
     #[inline]
     fn serialized_size(&self, compress: Compress) -> usize {
-        8 + self.as_ref().map(|s| s.serialized_size(compress)).unwrap_or(0)
+        bool::serialized_size(&self.is_some(), compress)
+            + self.as_ref().map(|s| s.serialized_size(compress)).unwrap_or(0)
     }
 }
 
@@ -504,7 +505,7 @@ impl<T: CanonicalSerialize> CanonicalSerialize for [T; 32] {
 
     #[inline]
     fn serialized_size(&self, compress: Compress) -> usize {
-        8 + self.iter().map(|item| item.serialized_size(compress)).sum::<usize>()
+        self.iter().map(|item| item.serialized_size(compress)).sum::<usize>()
     }
 }
 
@@ -642,10 +643,12 @@ mod test {
             (Compress::Yes, Validate::Yes),
         ];
         for (compress, validate) in combinations {
-            let mut serialized = vec![0; data.serialized_size(compress)];
-            data.serialize_with_mode(&mut serialized[..], compress).unwrap();
+            let mut serialized = vec![];
+            data.serialize_with_mode(&mut serialized, compress).unwrap();
             let de = T::deserialize_with_mode(&serialized[..], compress, validate).unwrap();
             assert_eq!(data, de);
+
+            assert_eq!(data.serialized_size(compress), serialized.len());
         }
     }
 
@@ -702,7 +705,9 @@ mod test {
 
     #[test]
     fn test_tuple() {
+        test_serialize((123u64, 234u32));
         test_serialize((123u64, 234u32, 999u16));
+        test_serialize((123u64, 234u32, 999u16, 88u8));
     }
 
     #[test]
@@ -719,5 +724,28 @@ mod test {
     #[test]
     fn test_phantomdata() {
         test_serialize(std::marker::PhantomData::<u64>);
+    }
+
+    #[test]
+    fn test_array_32() {
+        let mut array = [0u64; 32];
+        for (i, item) in array.iter_mut().enumerate() {
+            *item = i as u64;
+        }
+        test_serialize(array);
+    }
+
+    #[test]
+    fn test_btreemap() {
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(1u32, "one".to_string());
+        map.insert(2u32, "two".to_string());
+        test_serialize(map);
+        test_serialize(std::collections::BTreeMap::<u32, u32>::new());
+    }
+
+    #[test]
+    fn test_arc() {
+        test_serialize(std::sync::Arc::new(vec![1u16, 2, 3]));
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #2956. This PR addresses inconsistencies in `CanonicalSerialize::serialized_size` implementations for `Option<T>` and fixed-size arrays, where the reported size did not accurately reflect the serialized byte stream. The changes ensure that `serialized_size` correctly accounts for all serialized components, preventing incorrect buffer allocations and deserialization failures.

## Test Plan

- `cargo test -p snarkvm-utilities` to verify the corrected `serialized_size` implementations and expanded serialization test coverage for various data structures (tuples, arrays, maps, Arcs).
- `cargo test -p snarkvm-curves` to confirm canonical serialization round-trips for `Fr` and `G1Affine` elements across all compress/validate combinations.

## Related PRs

Fixes https://github.com/ProvableHQ/snarkVM/issues/2956

---
<a href="https://cursor.com/background-agent?bcId=bc-863ac239-07da-4dbb-bac3-acffc01e77b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-863ac239-07da-4dbb-bac3-acffc01e77b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

