### PR TITLE
Lagrange proof system support

### DIFF
--- a/algorithms/benches/snark/varuna.rs
+++ b/algorithms/benches/snark/varuna.rs
@@ -20,13 +20,21 @@ use snarkvm_algorithms::{
     AlgebraicSponge,
     SNARK,
     crypto_hash::PoseidonSponge,
-    snark::varuna::{CircuitVerifyingKey, TestCircuit, VarunaHidingMode, VarunaSNARK, VarunaVersion, ahp::AHPForR1CS},
+    polycommit::sonic_pc::CommitterKey,
+    snark::varuna::{
+        CircuitVerifyingKey,
+        TestCircuit,
+        VarunaHidingMode,
+        VarunaSNARK,
+        VarunaVersion,
+        ahp::AHPForR1CS,
+    },
 };
 use snarkvm_curves::bls12_377::{Bls12_377, Fq, Fr};
 use snarkvm_utilities::{CanonicalDeserialize, CanonicalSerialize, TestRng};
 
 use criterion::Criterion;
-use std::{collections::BTreeMap, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 type VarunaInst = VarunaSNARK<Bls12_377, FS, VarunaHidingMode>;
 type FS = PoseidonSponge<Fq, 2, 1>;
@@ -134,6 +142,62 @@ fn snark_batch_prove(c: &mut Criterion) {
                 .unwrap()
         })
     });
+}
+
+fn snark_prove_large_lagrange_vs_monomial(c: &mut Criterion) {
+    // Large instance (intended to make commitment cost noticeable).
+    let num_constraints = (1 << 15) - 10;
+    let num_variables = (1 << 15) - 10;
+    let mul_depth = 2;
+
+    // Setup once (not benchmarked).
+    let mut rng = TestRng::fixed(424242);
+    let (circuit, _public_inputs) = TestCircuit::gen_rand(mul_depth, num_constraints, num_variables, &mut rng);
+    let indexed = AHPForR1CS::<Fr, VarunaHidingMode>::index(&circuit).unwrap();
+    let max_degree = indexed.max_degree().unwrap();
+
+    let universal_srs = VarunaInst::universal_setup(max_degree).unwrap();
+    let universal_prover = &universal_srs.to_universal_prover().unwrap();
+    let fs_parameters = FS::sample_parameters();
+    let varuna_version = VarunaVersion::V2;
+
+    let (pk_lagrange, _vk) = VarunaInst::circuit_setup(&universal_srs, &circuit).unwrap();
+    let pk_monomial = {
+        // Reuse the proving key, but remove Lagrange bases from the committer key to force
+        // monomial-basis commitments throughout proving.
+        let ck = pk_lagrange.committer_key.as_ref();
+        let committer_key = CommitterKey {
+            powers_of_beta_g: ck.powers_of_beta_g.clone(),
+            lagrange_bases_at_beta_g: Default::default(),
+            powers_of_beta_times_gamma_g: ck.powers_of_beta_times_gamma_g.clone(),
+            shifted_powers_of_beta_g: ck.shifted_powers_of_beta_g.clone(),
+            shifted_powers_of_beta_times_gamma_g: ck.shifted_powers_of_beta_times_gamma_g.clone(),
+            enforced_degree_bounds: ck.enforced_degree_bounds.clone(),
+        };
+        let mut pk = pk_lagrange.clone();
+        pk.committer_key = Arc::new(committer_key);
+        pk
+    };
+
+    let mut group = c.benchmark_group("snark_prove_large_lagrange_vs_monomial");
+    group.measurement_time(Duration::from_secs(20));
+
+    group.bench_function("prove_lagrange", |b| {
+        b.iter(|| {
+            let mut iter_rng = TestRng::fixed(999);
+            VarunaInst::prove(universal_prover, &fs_parameters, &pk_lagrange, varuna_version, &circuit, &mut iter_rng)
+                .unwrap()
+        })
+    });
+
+    group.bench_function("prove_monomial", |b| {
+        b.iter(|| {
+            let mut iter_rng = TestRng::fixed(999);
+            VarunaInst::prove(universal_prover, &fs_parameters, &pk_monomial, varuna_version, &circuit, &mut iter_rng)
+                .unwrap()
+        })
+    });
+    group.finish();
 }
 
 fn snark_verify(c: &mut Criterion) {
@@ -344,7 +408,7 @@ fn snark_certificate_verify(c: &mut Criterion) {
 criterion_group! {
     name = varuna_snark;
     config = Criterion::default().measurement_time(Duration::from_secs(10));
-    targets = snark_universal_setup, snark_circuit_setup, snark_prove, snark_verify, snark_batch_prove, snark_batch_verify, snark_vk_serialize, snark_vk_deserialize, snark_certificate_prove, snark_certificate_verify,
+    targets = snark_universal_setup, snark_circuit_setup, snark_prove, snark_prove_large_lagrange_vs_monomial, snark_verify, snark_batch_prove, snark_batch_verify, snark_vk_serialize, snark_vk_deserialize, snark_certificate_prove, snark_certificate_verify,
 }
 
 criterion_main!(varuna_snark);

--- a/algorithms/src/snark/varuna/tests.rs
+++ b/algorithms/src/snark/varuna/tests.rs
@@ -244,8 +244,8 @@ mod varuna {
     fn prove_and_verify_with_tall_matrix_big() {
         let num_constraints = 100;
         let num_variables = 25;
-        let pk_size_zk = 91971;
-        let pk_size_posw = 91633;
+        let pk_size_zk = 138547;
+        let pk_size_posw = 138209;
         let mut rng = TestRng::default();
 
         SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
@@ -265,8 +265,8 @@ mod varuna {
     fn prove_and_verify_with_tall_matrix_small() {
         let num_constraints = 26;
         let num_variables = 25;
-        let pk_size_zk = 25428;
-        let pk_size_posw = 25090;
+        let pk_size_zk = 34748;
+        let pk_size_posw = 34410;
         let mut rng = TestRng::default();
 
         SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
@@ -286,8 +286,8 @@ mod varuna {
     fn prove_and_verify_with_squat_matrix_big() {
         let num_constraints = 25;
         let num_variables = 100;
-        let pk_size_zk = 53523;
-        let pk_size_posw = 53185;
+        let pk_size_zk = 100099;
+        let pk_size_posw = 99761;
         let mut rng = TestRng::default();
 
         SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
@@ -307,8 +307,8 @@ mod varuna {
     fn prove_and_verify_with_squat_matrix_small() {
         let num_constraints = 25;
         let num_variables = 26;
-        let pk_size_zk = 25284;
-        let pk_size_posw = 24946;
+        let pk_size_zk = 34604;
+        let pk_size_posw = 34266;
         let mut rng = TestRng::default();
 
         SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);
@@ -328,8 +328,8 @@ mod varuna {
     fn prove_and_verify_with_square_matrix() {
         let num_constraints = 25;
         let num_variables = 25;
-        let pk_size_zk = 25284;
-        let pk_size_posw = 24946;
+        let pk_size_zk = 34604;
+        let pk_size_posw = 34266;
         let mut rng = TestRng::default();
 
         SonicPCTest::test_circuit(num_constraints, num_variables, pk_size_zk, VarunaVersion::V1, &mut rng);

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -627,7 +627,7 @@ where
         let (fifth_commitments, fifth_commitment_randomnesses) = SonicKZG10::<E, FS>::commit(
             universal_prover,
             &committer_key,
-            fifth_oracles.iter().map(Into::into),
+            fifth_oracles.iter().map(|p| Self::poly_for_commit(&committer_key, p)),
             SM::ZK.then_some(zk_rng),
         )?;
         end_timer!(fifth_round_comm_time);

--- a/algorithms/src/snark/varuna/varuna.rs
+++ b/algorithms/src/snark/varuna/varuna.rs
@@ -24,6 +24,8 @@ use crate::{
         CommitterUnionKey,
         Evaluations,
         LabeledCommitment,
+        LabeledPolynomial,
+        LabeledPolynomialWithBasis,
         QuerySet,
         Randomness,
         SonicKZG10,
@@ -52,7 +54,7 @@ use anyhow::{Result, anyhow, bail, ensure};
 use core::marker::PhantomData;
 use itertools::Itertools;
 use rand::{CryptoRng, Rng};
-use std::{borrow::Borrow, collections::BTreeMap, ops::Deref, sync::Arc};
+use std::{borrow::Borrow, collections::{BTreeMap, BTreeSet}, ops::Deref, sync::Arc};
 
 use crate::srs::UniversalProver;
 
@@ -90,7 +92,36 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
 
             // Varuna only needs degree 2 random polynomials.
             let supported_hiding_bound = 1;
-            let supported_lagrange_sizes = [].into_iter(); // TODO: consider removing lagrange_bases_at_beta_g from CommitterKey
+            // Provide Lagrange bases for common domains used by Varuna, enabling optional
+            // Lagrange-basis commitments during proving (when the basis is large enough).
+            //
+            // Note: We filter sizes by `universal_srs.max_degree() + 1`, as required by
+            // the underlying KZG10 Lagrange basis construction.
+            let max_lagrange_size = universal_srs.max_degree() + 1;
+            let mut supported_lagrange_sizes = BTreeSet::new();
+            let mut maybe_insert = |size: usize| {
+                if size.is_power_of_two() && size <= max_lagrange_size {
+                    supported_lagrange_sizes.insert(size);
+                }
+            };
+            let info = &indexed_circuit.index_info;
+            let constraint_size = EvaluationDomain::<E::Fr>::compute_size_of_domain(info.num_constraints).unwrap();
+            let variable_size =
+                EvaluationDomain::<E::Fr>::compute_size_of_domain(info.num_public_and_private_variables).unwrap();
+            let non_zero_a_size = EvaluationDomain::<E::Fr>::compute_size_of_domain(info.num_non_zero_a).unwrap();
+            let non_zero_b_size = EvaluationDomain::<E::Fr>::compute_size_of_domain(info.num_non_zero_b).unwrap();
+            let non_zero_c_size = EvaluationDomain::<E::Fr>::compute_size_of_domain(info.num_non_zero_c).unwrap();
+
+            // Round 1 (witness & mask) and round 3 (h_1) can require ~2*|C|.
+            maybe_insert(variable_size);
+            maybe_insert(variable_size.saturating_mul(2));
+            // Round 2 (h_0) can require ~2*|R|.
+            maybe_insert(constraint_size.saturating_mul(2));
+            // Round 5 (h_2) fits within max non-zero domain sizes.
+            maybe_insert(non_zero_a_size);
+            maybe_insert(non_zero_b_size);
+            maybe_insert(non_zero_c_size);
+
             let (committer_key, _) = SonicKZG10::<E, FS>::trim(
                 universal_srs,
                 indexed_circuit.max_degree()?,
@@ -196,6 +227,31 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, SM: SNARKMode> VarunaSNARK
         for sum in sums.iter() {
             sponge.absorb_nonnative_field_elements([sum.sum_a, sum.sum_b, sum.sum_c]);
         }
+    }
+
+    /// Prepare a polynomial for committing, opportunistically using a supported Lagrange basis.
+    ///
+    /// - Degree-bounded polynomials must remain in monomial form, as degree-bounds are enforced
+    ///   via shifted powers in the SRS.
+    /// - Otherwise, if `ck` supports a Lagrange basis of size at least `poly.degree() + 1`,
+    ///   we commit using Lagrange evaluations on that domain.
+    fn poly_for_commit<'a>(ck: &CommitterUnionKey<E>, poly: &'a LabeledPolynomial<E::Fr>) -> LabeledPolynomialWithBasis<'a, E::Fr> {
+        // Preserve degree bounds (enforced via shifted powers).
+        if poly.degree_bound().is_some() {
+            return poly.into();
+        }
+
+        // Choose the smallest supported Lagrange domain size that is large enough.
+        let min_size = poly.degree().saturating_add(1);
+        let Some((&size, _)) = ck.lagrange_bases_at_beta_g.range(min_size..).next() else {
+            return poly.into();
+        };
+        let Some(domain) = EvaluationDomain::<E::Fr>::new(size) else {
+            return poly.into();
+        };
+
+        let evals = crate::fft::Polynomial::<E::Fr>::evaluate_over_domain(poly.polynomial().clone(), domain);
+        LabeledPolynomialWithBasis::new_lagrange_basis(poly.to_label(), evals, poly.hiding_bound())
     }
 }
 
@@ -409,7 +465,7 @@ where
             SonicKZG10::<E, FS>::commit(
                 universal_prover,
                 &committer_key,
-                first_round_oracles.iter().map(Into::into),
+                first_round_oracles.iter().map(|p| Self::poly_for_commit(&committer_key, p)),
                 SM::ZK.then_some(zk_rng),
             )?
         };
@@ -437,7 +493,7 @@ where
         let (second_commitments, second_commitment_randomnesses) = SonicKZG10::<E, FS>::commit(
             universal_prover,
             &committer_key,
-            second_oracles.iter().map(Into::into),
+            second_oracles.iter().map(|p| Self::poly_for_commit(&committer_key, p)),
             SM::ZK.then_some(zk_rng),
         )?;
         end_timer!(second_round_comm_time);
@@ -497,7 +553,7 @@ where
         let (third_commitments, third_commitment_randomnesses) = SonicKZG10::<E, FS>::commit(
             universal_prover,
             &committer_key,
-            third_oracles.iter().map(Into::into),
+            third_oracles.iter().map(|p| Self::poly_for_commit(&committer_key, p)),
             SM::ZK.then_some(zk_rng),
         )?;
         end_timer!(third_round_comm_time);
@@ -545,7 +601,7 @@ where
         let (fourth_commitments, fourth_commitment_randomnesses) = SonicKZG10::<E, FS>::commit(
             universal_prover,
             &committer_key,
-            fourth_oracles.iter().map(Into::into),
+            fourth_oracles.iter().map(|p| Self::poly_for_commit(&committer_key, p)),
             SM::ZK.then_some(zk_rng),
         )?;
         end_timer!(fourth_round_comm_time);


### PR DESCRIPTION
## Motivation

This PR adjusts the Varuna proof system to optionally commit polynomials in the Lagrange basis when supported by the `CommitterKey`. This can lead to more efficient proving by leveraging precomputed Lagrange bases.

Specifically:
*   `VarunaSNARK::batch_circuit_setup` now populates `CommitterKey::supported_lagrange_sizes` with relevant domain sizes derived from the circuit.
*   `VarunaSNARK::prove_batch` now uses a new helper `poly_for_commit` to opportunistically commit round polynomials (for rounds 1-4) in the Lagrange basis if a suitable basis is available in the `CommitterKey` and the polynomial is not degree-bounded.

## Test Plan

The Varuna test suite was run to verify the changes. Expected proving key sizes in `algorithms/src/snark/varuna/tests.rs` were updated to reflect the inclusion of Lagrange bases in the `CommitterKey`.

## Documentation

No external documentation updates are required as this is an internal optimization to the proving system.

## Backwards compatibility

This change is an internal optimization to the proving process and does not introduce any breaking changes or require a new `ConsensusVersion`.

---
<a href="https://cursor.com/background-agent?bcId=bc-207118f2-93e6-453a-9c4a-7f8d3ddeb4bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-207118f2-93e6-453a-9c4a-7f8d3ddeb4bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

